### PR TITLE
[WIP NOT TESTED] General refactoring and cleanup

### DIFF
--- a/src/android/ClientCertificateAuthentication.java
+++ b/src/android/ClientCertificateAuthentication.java
@@ -24,8 +24,8 @@ import java.util.concurrent.ExecutorService;
 public class ClientCertificateAuthentication extends CordovaPlugin {
 
     private static final String CRYPTO_RSA = "RSA";
-    public static final String SP_KEY_ALIAS = "SP_KEY_ALIAS";
-    public static final String TAG = "client-cert-auth";
+    private static final String SP_KEY_ALIAS = "SP_KEY_ALIAS";
+    private static final String TAG = "client-cert-auth";
 
     X509Certificate[] mCertificates;
     PrivateKey mPrivateKey;

--- a/src/android/ClientCertificateAuthentication.java
+++ b/src/android/ClientCertificateAuthentication.java
@@ -23,6 +23,7 @@ import java.util.concurrent.ExecutorService;
 @TargetApi(Build.VERSION_CODES.LOLLIPOP)
 public class ClientCertificateAuthentication extends CordovaPlugin {
 
+    private static final String CRYPTO_RSA = "RSA";
     public static final String SP_KEY_ALIAS = "SP_KEY_ALIAS";
     public static final String TAG = "client-cert-auth";
 
@@ -53,7 +54,7 @@ public class ClientCertificateAuthentication extends CordovaPlugin {
 
         if (alias == null) {
             KeyChain.choosePrivateKeyAlias(
-                cordova.getActivity(), callback, new String[]{"RSA"}, null, request.getHost(), request.getPort(), null);
+                cordova.getActivity(), callback, new String[]{CRYPTO_RSA}, null, request.getHost(), request.getPort(), null);
         } else {
             ExecutorService threadPool = cordova.getThreadPool();
             threadPool.submit(new Runnable() {

--- a/src/android/ClientCertificateAuthentication.java
+++ b/src/android/ClientCertificateAuthentication.java
@@ -10,6 +10,7 @@ import android.security.KeyChainAliasCallback;
 import android.security.KeyChainException;
 import android.util.Log;
 import android.widget.Toast;
+
 import org.apache.cordova.CordovaPlugin;
 import org.apache.cordova.CordovaWebView;
 import org.apache.cordova.ICordovaClientCertRequest;

--- a/src/android/ClientCertificateAuthentication.java
+++ b/src/android/ClientCertificateAuthentication.java
@@ -36,8 +36,6 @@ public class ClientCertificateAuthentication extends CordovaPlugin {
         return super.shouldAllowBridgeAccess(url);
     }
 
-
-    @TargetApi(Build.VERSION_CODES.ICE_CREAM_SANDWICH)
     @Override
     public boolean onReceivedClientCertRequest(CordovaWebView view, ICordovaClientCertRequest request) {
         if (mCertificates == null || mPrivateKey == null) {

--- a/src/android/ClientCertificateAuthentication.java
+++ b/src/android/ClientCertificateAuthentication.java
@@ -23,7 +23,6 @@ import java.util.concurrent.ExecutorService;
 @TargetApi(Build.VERSION_CODES.LOLLIPOP)
 public class ClientCertificateAuthentication extends CordovaPlugin {
 
-
     public static final String SP_KEY_ALIAS = "SP_KEY_ALIAS";
     public static final String TAG = "client-cert-auth";
 
@@ -68,7 +67,6 @@ public class ClientCertificateAuthentication extends CordovaPlugin {
 
 
     static class PrivateKeyAliasCallback implements KeyChainAliasCallback {
-
 
         private final SharedPreferences mPreferences;
         private final ICordovaClientCertRequest mRequest;

--- a/src/android/ClientCertificateAuthentication.java
+++ b/src/android/ClientCertificateAuthentication.java
@@ -19,7 +19,6 @@ import java.security.PrivateKey;
 import java.security.cert.X509Certificate;
 import java.util.concurrent.ExecutorService;
 
-
 @TargetApi(Build.VERSION_CODES.LOLLIPOP)
 public class ClientCertificateAuthentication extends CordovaPlugin {
 
@@ -30,7 +29,6 @@ public class ClientCertificateAuthentication extends CordovaPlugin {
     X509Certificate[] mCertificates;
     PrivateKey mPrivateKey;
     String mAlias;
-
 
     @Override
     public Boolean shouldAllowBridgeAccess(String url) {
@@ -65,7 +63,6 @@ public class ClientCertificateAuthentication extends CordovaPlugin {
             });
         }
     }
-
 
     static class PrivateKeyAliasCallback implements KeyChainAliasCallback {
 
@@ -103,7 +100,6 @@ public class ClientCertificateAuthentication extends CordovaPlugin {
             }
         }
     }
-
 
     private void proceedWithRequest(ICordovaClientCertRequest request) {
         request.proceed(mPrivateKey, mCertificates);

--- a/src/android/ClientCertificateAuthentication.java
+++ b/src/android/ClientCertificateAuthentication.java
@@ -39,14 +39,14 @@ public class ClientCertificateAuthentication extends CordovaPlugin {
     @Override
     public boolean onReceivedClientCertRequest(CordovaWebView view, ICordovaClientCertRequest request) {
         if (mCertificates == null || mPrivateKey == null) {
-            loadKeys(request);
+            choosePrivateKey(request);
         } else {
-            proceedRequers(request);
+            proceedWithRequest(request);
         }
         return true;
     }
 
-    private void loadKeys(ICordovaClientCertRequest request) {
+    private void choosePrivateKey(ICordovaClientCertRequest request) {
         SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(cordova.getActivity());
         final KeyChainAliasCallback callback = new PrivateKeyAliasCallback(cordova.getActivity(), request);
         final String alias = sp.getString(SP_KEY_ALIAS, null);
@@ -105,7 +105,7 @@ public class ClientCertificateAuthentication extends CordovaPlugin {
     }
 
 
-    public void proceedRequers(ICordovaClientCertRequest request) {
+    private void proceedWithRequest(ICordovaClientCertRequest request) {
         request.proceed(mPrivateKey, mCertificates);
     }
 }

--- a/src/android/ClientCertificateAuthentication.java
+++ b/src/android/ClientCertificateAuthentication.java
@@ -52,7 +52,8 @@ public class ClientCertificateAuthentication extends CordovaPlugin {
         final String alias = sp.getString(SP_KEY_ALIAS, null);
 
         if (alias == null) {
-            KeyChain.choosePrivateKeyAlias(cordova.getActivity(), callback, new String[]{"RSA"}, null, request.getHost(), request.getPort(), null);
+            KeyChain.choosePrivateKeyAlias(
+                cordova.getActivity(), callback, new String[]{"RSA"}, null, request.getHost(), request.getPort(), null);
         } else {
             ExecutorService threadPool = cordova.getThreadPool();
             threadPool.submit(new Runnable() {

--- a/src/android/ClientCertificateAuthentication.java
+++ b/src/android/ClientCertificateAuthentication.java
@@ -103,8 +103,6 @@ public class ClientCertificateAuthentication extends CordovaPlugin {
         }
     }
 
-    ;
-
 
     public void proceedRequers(ICordovaClientCertRequest request) {
         request.proceed(mPrivateKey, mCertificates);

--- a/src/android/ClientCertificateAuthentication.java
+++ b/src/android/ClientCertificateAuthentication.java
@@ -48,7 +48,7 @@ public class ClientCertificateAuthentication extends CordovaPlugin {
 
     private void loadKeys(ICordovaClientCertRequest request) {
         SharedPreferences sp = PreferenceManager.getDefaultSharedPreferences(cordova.getActivity());
-        final KeyChainAliasCallback callback = new AliasCallback(cordova.getActivity(), request);
+        final KeyChainAliasCallback callback = new PrivateKeyAliasCallback(cordova.getActivity(), request);
         final String alias = sp.getString(SP_KEY_ALIAS, null);
 
         if (alias == null) {
@@ -66,14 +66,14 @@ public class ClientCertificateAuthentication extends CordovaPlugin {
     }
 
 
-    static class AliasCallback implements KeyChainAliasCallback {
+    static class PrivateKeyAliasCallback implements KeyChainAliasCallback {
 
 
         private final SharedPreferences mPreferences;
         private final ICordovaClientCertRequest mRequest;
         private final Context mContext;
 
-        public AliasCallback(Context context, ICordovaClientCertRequest request) {
+        public PrivateKeyAliasCallback(Context context, ICordovaClientCertRequest request) {
             mRequest = request;
             mContext = context;
             mPreferences = PreferenceManager.getDefaultSharedPreferences(mContext);


### PR DESCRIPTION
I made these low-risk changes on the GitHub UI, not yet tested. I think there should be a low risk of build failure and even lower risk of new run-time issues.

- remove redundant `@TargetApi` from callback method, as a higher `@TargetApi` value was already specified for the plugin class
- cleanup: remove an extra semicolon (that is not needed)
- cleanup: split long `KeyChain.choosePrivateKeyAlias()` line
- rename inner class to `PrivateKeyAliasCallback`
- rename the internal methods (and make the second internal method private)
- cleanup: add blank line to imports
- cleanup: remove extra blank lines before final constants
- use internal `CRYPTO_RSA` constant instead of hardcoded string
- make other internal constant strings private
- cleanup: remove more extra blank lines

TODO items:

- [ ] _test that this plugin continues to build and run correctly with these changes_
- [ ] I think JavaDoc comments should be added for the sake of clarity. This idea was triggered by the extra blank lines.
- [ ] Use RSA string from `android.security.keystore.KeyProperties.KEY_ALGORITHM_RSA` (`KeyProperties.KEY_ALGORITHM_RSA`) - see https://github.com/mibrito707/cordova-plugin-secure-storage/blob/f07cf1e2d14607c60f7cd5c17b7fe7c1149922cb/src/android/RSA.java#L176
- [ ] _the inner `PrivateKeyAliasCallback` class should be private_

This proposal was triggered by my attempt to understand the general behavior and “how it works” of this implementation.

I hope I will get a chance to continue with these changes with some decent testing, someday.